### PR TITLE
feat(docs): add templates and guidelines for Architectural Decision Records (ADRs)

### DIFF
--- a/.github/prompts/create-architectural-decision-record.prompt.md
+++ b/.github/prompts/create-architectural-decision-record.prompt.md
@@ -1,0 +1,89 @@
+---
+mode: 'agent'
+description: 'Create an Architectural Decision Record (ADR) document for AI-optimized decision documentation.'
+tools: ['changes', 'codebase', 'editFiles', 'extensions', 'fetch', 'githubRepo', 'openSimpleBrowser', 'problems', 'runTasks', 'search', 'searchResults', 'terminalLastCommand', 'terminalSelection', 'testFailure', 'usages', 'vscodeAPI']
+---
+# Create Architectural Decision Record
+
+Create an ADR document for `${input:DecisionTitle}` using structured formatting optimized for AI consumption and human readability.
+
+## Inputs
+
+- **Context**: `${input:Context}`
+- **Decision**: `${input:Decision}`
+- **Alternatives**: `${input:Alternatives}`
+- **Stakeholders**: `${input:Stakeholders}`
+
+## Input Validation
+If any of the required inputs are not provided or cannot be determined from the conversation history, ask the user to provide the missing information before proceeding with ADR generation.
+
+## Requirements
+
+- Use precise, unambiguous language
+- Follow standardized ADR format with front matter
+- Include both positive and negative consequences
+- Document alternatives with rejection rationale
+- Structure for machine parsing and human reference
+- Use coded bullet points (3-4 letter codes + 3-digit numbers) for multi-item sections
+
+The ADR must be saved in the `/docs/adr/` directory using the naming convention: `NNNN-[title-slug].md`, where NNNN is the next sequential 4-digit number (e.g., `0001-database-selection.md`).
+
+## Required Documentation Structure
+
+The documentation file must follow the template below, ensuring that all sections are filled out appropriately. The front matter for the markdown should be structured correctly as per the example following:
+
+```md
+---
+title: "NNNN: [Decision Title]"
+supersedes: ""
+superseded_by: ""
+---
+
+# NNNN: [Decision Title]
+
+## Context
+
+[Problem statement, technical constraints, business requirements, and environmental factors requiring this decision.]
+
+## Decision
+
+[Chosen solution with clear rationale for selection.]
+
+## Consequences
+
+### Positive
+
+- **POS-001**: [Beneficial outcomes and advantages]
+- **POS-002**: [Performance, maintainability, scalability improvements]
+- **POS-003**: [Alignment with architectural principles]
+
+### Negative
+
+- **NEG-001**: [Trade-offs, limitations, drawbacks]
+- **NEG-002**: [Technical debt or complexity introduced]
+- **NEG-003**: [Risks and future challenges]
+
+## Alternatives Considered
+
+### [Alternative 1 Name]
+
+- **ALT-001**: **Description**: [Brief technical description]
+- **ALT-002**: **Rejection Reason**: [Why this option was not selected]
+
+### [Alternative 2 Name]
+
+- **ALT-003**: **Description**: [Brief technical description]
+- **ALT-004**: **Rejection Reason**: [Why this option was not selected]
+
+## Implementation Notes
+
+- **IMP-001**: [Key implementation considerations]
+- **IMP-002**: [Migration or rollout strategy if applicable]
+- **IMP-003**: [Monitoring and success criteria]
+
+## References
+
+- **REF-001**: [Related ADRs]
+- **REF-002**: [External documentation]
+- **REF-003**: [Standards or frameworks referenced]
+```

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -1,0 +1,150 @@
+# Architectural Decision Records (ADRs)
+
+## What are ADRs?
+
+Architectural Decision Records (ADRs) are documents that capture important architectural decisions along with their context and consequences. They serve as a historical record of the technical choices made in this project, helping current and future developers understand why certain decisions were made.
+
+ADRs are particularly valuable for:
+- Documenting the reasoning behind architectural choices
+- Providing context for future decision-making
+- Onboarding new team members
+- Reviewing and potentially reversing past decisions
+- Maintaining institutional knowledge
+
+## Current ADRs
+
+This directory currently contains the following ADRs:
+
+*No ADRs have been created yet.*
+
+## ADR Template
+
+All ADRs in this project follow a standardized template optimized for both AI consumption and human readability. The template includes structured formatting with coded bullet points for easy parsing and reference.
+
+### File Naming Convention
+
+ADR files should be named using the following pattern:
+```
+NNNN-[title-slug].md
+```
+
+Where:
+- `NNNN` is a 4-digit sequential number (e.g., 0001, 0002, etc.)
+- `[title-slug]` is a lowercase, hyphenated version of the decision title
+
+Examples:
+- `0001-database-selection.md`
+- `0002-frontend-framework-choice.md`
+
+### Template Structure
+
+```md
+---
+title: "NNNN: [Decision Title]"
+supersedes: ""
+superseded_by: ""
+---
+
+# NNNN: [Decision Title]
+
+## Context
+
+[Problem statement, technical constraints, business requirements, and environmental factors requiring this decision.]
+
+## Decision
+
+[Chosen solution with clear rationale for selection.]
+
+## Consequences
+
+### Positive
+
+- **POS-001**: [Beneficial outcomes and advantages]
+- **POS-002**: [Performance, maintainability, scalability improvements]
+- **POS-003**: [Alignment with architectural principles]
+
+### Negative
+
+- **NEG-001**: [Trade-offs, limitations, drawbacks]
+- **NEG-002**: [Technical debt or complexity introduced]
+- **NEG-003**: [Risks and future challenges]
+
+## Alternatives Considered
+
+### [Alternative 1 Name]
+
+- **ALT-001**: **Description**: [Brief technical description]
+- **ALT-002**: **Rejection Reason**: [Why this option was not selected]
+
+### [Alternative 2 Name]
+
+- **ALT-003**: **Description**: [Brief technical description]
+- **ALT-004**: **Rejection Reason**: [Why this option was not selected]
+
+## Implementation Notes
+
+- **IMP-001**: [Key implementation considerations]
+- **IMP-002**: [Migration or rollout strategy if applicable]
+- **IMP-003**: [Monitoring and success criteria]
+
+## References
+
+- **REF-001**: [Related ADRs]
+- **REF-002**: [External documentation]
+- **REF-003**: [Standards or frameworks referenced]
+```
+
+## Creating a New ADR
+
+To create a new ADR:
+
+1. **Determine the next sequential number** by checking the existing ADRs in this directory
+2. **Use the template above** as your starting point
+3. **Fill in all required sections**:
+   - Context: Explain the problem and constraints
+   - Decision: Document the chosen solution
+   - Consequences: List both positive and negative outcomes
+   - Alternatives: Document other options considered and why they were rejected
+   - Implementation Notes: Include practical considerations
+   - References: Link to related documentation
+
+4. **Use coded bullet points** (e.g., POS-001, NEG-001, ALT-001) for structured sections
+5. **Save the file** using the proper naming convention
+6. **Update this README** to list the new ADR
+
+## Guidelines for Writing ADRs
+
+### Language and Style
+- Use precise, unambiguous language
+- Write for both current team members and future developers
+- Be objective and factual rather than subjective
+- Include technical details where relevant
+
+### Content Requirements
+- **Context**: Provide enough background for someone unfamiliar with the situation to understand the decision
+- **Decision**: Be clear about exactly what was decided
+- **Consequences**: Include both immediate and long-term implications
+- **Alternatives**: Show that other options were considered and explain the trade-offs
+- **Implementation**: Include practical guidance for implementing the decision
+
+### Structure for Machine Parsing
+- Use consistent front matter (YAML metadata)
+- Follow the coded bullet point system for multi-item sections
+- Maintain consistent heading hierarchy
+
+## Review Process
+
+All ADRs should be reviewed by relevant stakeholders before implementation. The review process ensures that:
+- All perspectives have been considered
+- The decision is technically sound
+- The documentation is clear and complete
+- The implications are well understood
+
+## Maintenance
+
+ADRs should be updated when:
+- New information becomes available that affects the decision
+- The decision is superseded by a new ADR
+- Implementation reveals additional consequences or considerations
+
+Remember: ADRs are living documents that should evolve with your understanding and the project's needs.


### PR DESCRIPTION
This pull request introduces a standardized process and template for creating Architectural Decision Records (ADRs) in the project. It adds both an agent prompt for generating ADRs and a comprehensive README with guidelines, naming conventions, and a template structure to the `docs/adrs` directory. These changes ensure that architectural decisions are documented in a consistent, structured, and machine-readable format, benefiting both AI tooling and human developers.

**ADR Process and Template Standardization**

* Added `.github/prompts/create-architectural-decision-record.prompt.md` to define an agent prompt for generating ADR documents, including required inputs, validation, and a detailed markdown template with coded bullet points for structured documentation.
* Created `docs/adrs/README.md` to explain the purpose and value of ADRs, provide file naming conventions, the standardized template, step-by-step instructions for creating new ADRs, and guidelines for writing, reviewing, and maintaining ADRs.