### PR TITLE
fix(adrs): ADRs folder was incorrect in Prompt File

### DIFF
--- a/.github/prompts/create-architectural-decision-record.prompt.md
+++ b/.github/prompts/create-architectural-decision-record.prompt.md
@@ -26,7 +26,7 @@ If any of the required inputs are not provided or cannot be determined from the 
 - Structure for machine parsing and human reference
 - Use coded bullet points (3-4 letter codes + 3-digit numbers) for multi-item sections
 
-The ADR must be saved in the `/docs/adr/` directory using the naming convention: `NNNN-[title-slug].md`, where NNNN is the next sequential 4-digit number (e.g., `0001-database-selection.md`).
+The ADR must be saved in the `/docs/adrs/` directory using the naming convention: `NNNN-[title-slug].md`, where NNNN is the next sequential 4-digit number (e.g., `0001-database-selection.md`).
 
 ## Required Documentation Structure
 


### PR DESCRIPTION
This pull request updates the documentation instructions for saving Architectural Decision Records (ADRs). The main change is a correction to the directory name where ADRs should be stored.

Documentation update:

* Changed the required directory for saving ADRs from `/docs/adr/` to `/docs/adrs/` in the `.github/prompts/create-architectural-decision-record.prompt.md` file to ensure consistency with the intended directory structure.